### PR TITLE
Use relative paths in all require statements.

### DIFF
--- a/distributions/beta_distribution.cr
+++ b/distributions/beta_distribution.cr
@@ -1,4 +1,4 @@
-require "distributions/probability_distribution"
+require "../distributions/probability_distribution"
 
 module Crystalstats
   class BetaDistribution < Crystalstats::ProbabilityDistribution 

--- a/distributions/binomial_distribution.cr
+++ b/distributions/binomial_distribution.cr
@@ -1,4 +1,4 @@
-require "distributions/probability_distribution"
+require "../distributions/probability_distribution"
 # This class provides an object for encapsulating binomial distributions
 # Ported to Ruby from PHPMath class by Bryan Donovan
 # Author:: Mark Hale

--- a/distributions/cauchy_distribution.cr
+++ b/distributions/cauchy_distribution.cr
@@ -1,4 +1,4 @@
-require "distributions/probability_distribution"
+require "../distributions/probability_distribution"
 module Crystalstats
   class CauchyDistribution < Crystalstats::ProbabilityDistribution
 

--- a/distributions/normal_distribution.cr
+++ b/distributions/normal_distribution.cr
@@ -1,4 +1,4 @@
-require "distributions/probability_distribution"
+require "../distributions/probability_distribution"
 # This class provides an object for encapsulating normal distributions
 # Ported to Ruby from PHPMath class by Bryan Donovan
 # Author:: Jaco van Kooten 

--- a/distributions/probability_distribution.cr
+++ b/distributions/probability_distribution.cr
@@ -1,4 +1,4 @@
-require "distributions/modules"
+require "../distributions/modules"
 
 module Crystalstats
   # The ProbabilityDistribution superclass provides an object 


### PR DESCRIPTION
When using this library as a shard without the environment variable `CRYSTAL_PATH` being set, some of the `require` statements fail. Most dependencies were already relative to the current file, but this PR fixes the five that were not.